### PR TITLE
SQR-5028 еще один фикс связанный с претставление текста запроса SphinxQu...

### DIFF
--- a/django_sphinx_db/backend/models.py
+++ b/django_sphinx_db/backend/models.py
@@ -73,7 +73,8 @@ class SphinxQuery(Query):
     def __unicode__(self):
         compiler = SphinxQLCompiler(self, connection, None)
         query, params = compiler.as_sql()
-        return query % params
+        return unicode(query % params)
+
 
 class SphinxQuerySet(QuerySet):
 

--- a/django_sphinx_db/tests.py
+++ b/django_sphinx_db/tests.py
@@ -108,7 +108,8 @@ class BackendTestCase(TestCase):
         ):
             qs = TagsIndex.objects.filter(name__exact=query_text)
             try:
-                # эквивалент: u"%s" % query_text
+                # преобразования к unicode и str работают корректно
                 unicode(qs.query)
-            except UnicodeDecodeError:
+                str(qs.query)
+            except (UnicodeDecodeError, UnicodeEncodeError):
                 self.fail('UnicodeDecodeError: %s' % query_text)


### PR DESCRIPTION
Короче ошибка не была исправлена и воспроизводилась следующим образом:

``` python
>>> s = '\xd1\x82\xd0\xb5\xd1\x81\xd1\x82'
>>> type(s)
<type 'str'>
>>> 
>>> print s
тест
>>> print u"%s" % s
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
UnicodeDecodeError: 'ascii' codec can't decode byte 0xd1 in position 0: ordinal not in range(128)
```

Добавил метод **unicode** для таких ситуаций и написал тест проверяющий все возможные варианты
